### PR TITLE
New version release of tile

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -46,15 +46,15 @@ The following table provides version and version-support information about Redis
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>v5.0.1180018</td>
+        <td>v5.0.13000030</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>February 5, 2018</td>
+        <td>March 5, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>Redis Enterprise v5.0.1</td>
+        <td>Redis Enterprise v5.0.1-31</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Redis Enterprise Pack for PCF
+title: Redis Enterprise for PCF
 owner: Partners
 ---
 <style>
@@ -18,28 +18,28 @@ owner: Partners
 </style>
 
 
-<p class="note warning"><strong>WARNING:</strong> Redis Enterprise Pack for PCF v5.0.x Beta is not intended for production use.
-   For production use, Redis Labs recommends Redis Enterprise Pack for PCF v0.0.81.</p>
+<p class="note warning"><strong>WARNING:</strong> Redis Enterprise for PCF v5.0.x Beta is not intended for production use.
+   For production use, Redis Labs recommends Redis Enterprise for PCF v0.0.81.</p>
 
-Redis Enterprise Pack clusters are enterprise-grade, highly available, and scalable Redis clusters with substantially lower operational overhead than any other Redis deployment method.
+Redis Enterprise clusters are enterprise-grade, highly available, and scalable Redis clusters with substantially lower operational overhead than any other Redis deployment method.
 
-Redis Enterprise Pack extends open source Redis and delivers tangible benefits of stable high performance, zero-downtime linear scaling, and hassle-free, true high availability, with significant operational savings.
+Redis Enterprise extends open source Redis and delivers tangible benefits of stable high performance, zero-downtime linear scaling, and hassle-free, true high availability, with significant operational savings.
 
-This documentation describes Redis Enterprise Pack for Pivotal Cloud Foundry (PCF).
-Redis Enterprise Pack for PCF exposes its service plans on the Marketplace.
+This documentation describes Redis Enterprise for Pivotal Cloud Foundry (PCF).
+Redis Enterprise for PCF exposes its service plans on the Marketplace.
 Developers can provision highly available and scalable Redis databases by creating instances of the service plans using Apps Manager or the Cloud Foundry Command Line Interface (cf CLI).
 
 ## <a id='overview'></a>Overview
 
-Redis Enterprise Pack is an enterprise-grade cluster that acts as a container for managing and running multiple Redis databases in a highly available and scalable manner.
+Redis Enterprise is an enterprise-grade cluster that acts as a container for managing and running multiple Redis databases in a highly available and scalable manner.
 
-By default, a three-node Redis Enterprise Pack cluster is deployed for you.
+By default, a three-node Redis Enterprise cluster is deployed for you.
 
-For specific information about Redis Enterprise Pack, and to get started, see the [Redis Enterprise Pack documentation](https://redislabs.com/redis-enterprise-documentation/overview/).
+For specific information about Redis Enterprise Pack, and to get started, see the [Redis Enterprise documentation](https://redislabs.com/redis-enterprise-documentation/overview/).
 
 ## <a id="snapshot"></a>Product Snapshot
 
-The following table provides version and version-support information about Redis Enterprise Pack for PCF.
+The following table provides version and version-support information about Redis Enterprise for PCF.
 
 <table class="nice">
     <th>Element</th>
@@ -54,7 +54,7 @@ The following table provides version and version-support information about Redis
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>Redis Enterprise Pack v5.0.1</td>
+        <td>Redis Enterprise v5.0.1</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -70,16 +70,16 @@ The following table provides version and version-support information about Redis
     </tr>
 </table>
 
-<p class="note info">Note: The versioning for this tile has changed from v0.0.84 to v5.0.X to match the official Redis Enterprise Pack pattern.</p>
+<p class="note info">Note: The versioning for this tile has changed from v0.0.84 to v5.0.X to match the official Redis Enterprise pattern.</p>
 
 ## <a id="reqs"></a>Requirements
 
-Redis Enterprise Pack for Pivotal Cloud Foundry requires a valid license from Redis Labs for the Redis Enterprise Pack cluster.
+Redis Enterprise for Pivotal Cloud Foundry requires a valid license from Redis Labs for the Redis Enterprise cluster.
 Otherwise, you receive a thirty-day trial license by default.
 
 ## <a id="limitations"></a>Limitations
 
-At this time, Redis Enterprise Pack for Pivotal Cloud Foundry is limited to one cluster per deployment.
+At this time, Redis Enterprise for Pivotal Cloud Foundry is limited to one cluster per deployment.
 
 ## <a id="feedback"></a>Feedback
 
@@ -87,4 +87,4 @@ Please provide any bugs, feature requests, or questions to the [Pivotal Cloud Fo
 
 ## <a id='license'></a>License
 
-Customers interested in using Redis Enterprise Pack for PCF can download the tile and install it with the trial license limitations. To obtain a production license and 24/7 support, please contact a [Redis Labs sales representative](mailto:sales@redislabs.com).
+Customers interested in using Redis Enterprise for PCF can download the tile and install it with the trial license limitations. To obtain a production license and 24/7 support, please contact a [Redis Labs sales representative](mailto:sales@redislabs.com).

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -54,7 +54,7 @@ The following table provides version and version-support information about Redis
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>Redis Enterprise v5.0.1-31</td>
+        <td>Redis Enterprise v5.0.1-30</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -1,9 +1,20 @@
 ---
-title: Redis Enterprise Pack for PCF Release Notes
+title: Redis Enterprise for PCF Release Notes
 owner: Partners
 ---
 
-These are release notes for Redis Enterprise Pack for PCF.
+These are release notes for Redis Enterprise for PCF.
+
+##<a id="ver"></a> 5.0.1180018 (BETA)
+
+**Release Date:** March 5, 2018
+
+###New Features
+
+- Built and tested new tile with PCF 1.12.12 (ERT and Ops Manager)
+- Updated Redislabs enterprise cluster version to 5.0.1-17
+- Upgrade support in Redis Enterprise tile
+- Syslog integration
 
 ##<a id="ver"></a> 5.0.1180018 (BETA)
 
@@ -38,24 +49,24 @@ For information, see <a href="https://www.redislabs.com/redis-enterprise-documen
 ###New Features
 
 **Support for Redis Cluster API**<br>
-The Redis Cluster API support in Redis Enterprise Pack provides a simple mechanism for Cluster-enabled Redis clients to learn and know the cluster topology. This enables clients to connect directly to an RP proxy on the node hosting the master shard for the data being operated on. As a result, all but the initial call to get the cluster topology or reacquire the location of the master shard, and the client will connect to the RP endpoint proxy where the master shard is located. <a href="https://www.redislabs.com/redis-enterprise-documentation/concepts-architecture/data-access/cluster-api/">Learn more about the Cluster API implementation</a>.
+The Redis Cluster API support in Redis Enterprise provides a simple mechanism for Cluster-enabled Redis clients to learn and know the cluster topology. This enables clients to connect directly to an RP proxy on the node hosting the master shard for the data being operated on. As a result, all but the initial call to get the cluster topology or reacquire the location of the master shard, and the client will connect to the RP endpoint proxy where the master shard is located. <a href="https://www.redislabs.com/redis-enterprise-documentation/concepts-architecture/data-access/cluster-api/">Learn more about the Cluster API implementation</a>.
 
 **Redis Modules**<br>
-Redis Modules enable you to extend the functionality of Redis Enterprise Pack. You can add new data types, capabilities, and more to tailor the cluster to a specific use case or need. Once installed, modules benefit from the high performance, scalability, and high availability that Redis Enterprise Pack is known for.
+Redis Modules enable you to extend the functionality of Redis Enterprise Pack. You can add new data types, capabilities, and more to tailor the cluster to a specific use case or need. Once installed, modules benefit from the high performance, scalability, and high availability that Redis Enterprise is known for.
 
 **Redis Labs' Modules**
 
 There are three modules Redis Labs has developed and certified with Redis Enterprise Pack. The modules are:
 <ul>
- 	<li><a href="https://www.redislabs.com/redis-enterprise-documentation/developing/modules/redisearch/">RediSearch</a> - This module turns Redis Enterprise Pack into a supercharged distributed in-memory full-text indexing and search beast.</li>
+ 	<li><a href="https://www.redislabs.com/redis-enterprise-documentation/developing/modules/redisearch/">RediSearch</a> - This module turns Redis Enterprise into a supercharged distributed in-memory full-text indexing and search beast.</li>
  	<li><a href="https://www.redislabs.com/redis-enterprise-documentation/developing/modules/rejson/">ReJSON</a> - Now you have the convenience of JSON as a built-in data type and can address nested data via a path easily.</li>
- 	<li><a href="https://redislabs.com/redis-enterprise-documentation/developing/modules/bloom-filters/">ReBloom</a> - Enables Redis Enterprise Pack to have a scalable bloom filter as a data type. Bloom filters are probabilistic data structures that quickly determine if something is contained within a set.</li>
+ 	<li><a href="https://redislabs.com/redis-enterprise-documentation/developing/modules/bloom-filters/">ReBloom</a> - Enables Redis Enterprise to have a scalable bloom filter as a data type. Bloom filters are probabilistic data structures that quickly determine if something is contained within a set.</li>
 </ul>
 **Custom Modules**
-In addition, Redis Enterprise Pack provides the ability to load and use custom modules from <a href="http://redismodules.com/">redismodules.com</a> or of your own creation.
+In addition, Redis Enterprise provides the ability to load and use custom modules from <a href="http://redismodules.com/">redismodules.com</a> or of your own creation.
 
 **LDAP Integration**
-As part of our continued emphasis on security, administrative user accounts in Redis Enterprise Pack can now either use built-in authentication or authenticate externally via LDAP with saslauthd. The accounts can be used for administering resources on the cluster via command line, Rest API, or Web UI.
+As part of our continued emphasis on security, administrative user accounts in Redis Enterprise can now either use built-in authentication or authenticate externally via LDAP with saslauthd. The accounts can be used for administering resources on the cluster via command line, Rest API, or Web UI.
 
 For more information see <a href="https://www.redislabs.com/redis-enterprise-documentation/administering/security/ldap-integration/">LDAP Integration</a>.
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -11,7 +11,7 @@ These are release notes for Redis Enterprise for PCF.
 
 ###New Features
 
-- PCSF 2.0.x Support
+- PCF 2.0.x Support
 - Added Smoke-test errand
 - Tile based on Redis-Enterprise 5.0.1-30
 - Stemcell 3541.5 support

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -11,10 +11,18 @@ These are release notes for Redis Enterprise for PCF.
 
 ###New Features
 
-- Built and tested new tile with PCF 1.12.12 (ERT and Ops Manager)
-- Updated Redislabs enterprise cluster version to 5.0.1-17
-- Upgrade support in Redis Enterprise tile
-- Syslog integration
+- PCSF 2.0.x Support
+- Added Smoke-test errand
+- Tile based on Redis-Enterprise 5.0.1-18
+- Stemcell 3541.5 support
+
+###Improvements
+- Using new Tile generator v11
+- Using final bosh releases in Tile
+
+###Fixed
+- Offline install capability
+- Issue related to default Syslog integration option
 
 ##<a id="ver"></a> 5.0.1180018 (BETA)
 
@@ -60,7 +68,7 @@ There are three modules Redis Labs has developed and certified with Redis Enterp
 <ul>
  	<li><a href="https://www.redislabs.com/redis-enterprise-documentation/developing/modules/redisearch/">RediSearch</a> - This module turns Redis Enterprise into a supercharged distributed in-memory full-text indexing and search beast.</li>
  	<li><a href="https://www.redislabs.com/redis-enterprise-documentation/developing/modules/rejson/">ReJSON</a> - Now you have the convenience of JSON as a built-in data type and can address nested data via a path easily.</li>
- 	<li><a href="https://redislabs.com/redis-enterprise-documentation/developing/modules/bloom-filters/">ReBloom</a> - Enables Redis Enterprise to have a scalable bloom filter as a data type. Bloom filters are probabilistic data structures that quickly determine if something is contained within a set.</li>
+ 	<li><a href="https://www.redislabs.com/redis-enterprise-documentation/developing/modules/bloom-filters/">ReBloom</a> - Enables Redis Enterprise to have a scalable bloom filter as a data type. Bloom filters are probabilistic data structures that quickly determine if something is contained within a set.</li>
 </ul>
 **Custom Modules**
 In addition, Redis Enterprise provides the ability to load and use custom modules from <a href="http://redismodules.com/">redismodules.com</a> or of your own creation.

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,7 +5,7 @@ owner: Partners
 
 These are release notes for Redis Enterprise for PCF.
 
-##<a id="ver"></a> 5.0.1180018 (BETA)
+##<a id="ver"></a> 5.0.13000030 (BETA)
 
 **Release Date:** March 5, 2018
 
@@ -13,7 +13,7 @@ These are release notes for Redis Enterprise for PCF.
 
 - PCSF 2.0.x Support
 - Added Smoke-test errand
-- Tile based on Redis-Enterprise 5.0.1-18
+- Tile based on Redis-Enterprise 5.0.1-30
 - Stemcell 3541.5 support
 
 ###Improvements

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -18,7 +18,7 @@ These are release notes for Redis Enterprise for PCF.
 
 ###Improvements
 - Using new Tile generator v11
-- Using final bosh releases in Tile
+- Using final BOSH releases in Tile
 
 ###Fixed
 - Offline install capability


### PR DESCRIPTION
New release of Redis Enterprise on PCF Tile.

- New version
- New branding
- Supports newer PCF features.
See release notes for more info